### PR TITLE
chore: update remaining actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
           if_key_exists: replace
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,14 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOSTS_GITHUB }}
           if_key_exists: replace
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install dependencies
         run: make install
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build frontend-legacy
         run: TAG_VERSION=${{ inputs.version }} helium-cli build-release ${{ inputs.version }} --projects frontend-legacy
       - name: Publish frontend-legacy artifacts


### PR DESCRIPTION
## Summary

Update remaining GitHub Actions to Node 24 compatible versions:

- `deploy.yml`: `docker/login-action@v3` -> `@v4`
- `release.yml`: `docker/login-action@v3` -> `@v4`
- `release.yml`: `docker/setup-buildx-action@v3` -> `@v4`