### PR TITLE
Skip Sentry and GA4 secrets when null

### DIFF
--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -144,6 +144,7 @@ variable "DD_API_KEY" {
 
 variable "SENTRY_DSN" {
   description = "The Sentry DSN for error tracking"
+  default     = null
 }
 
 variable "FIREBASE_PROJECT_ID" {
@@ -172,8 +173,10 @@ variable "FIREBASE_CLIENT_X509_CERT_URL" {
 
 variable "GA4_MEASUREMENT_ID" {
   description = "The GA4 Measurement ID (G-XXXXXXXXXX) for the backend Measurement Protocol client"
+  default     = null
 }
 
 variable "GA4_API_SECRET" {
   description = "The GA4 Measurement Protocol API secret for the backend analytics client"
+  default     = null
 }

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -118,6 +118,7 @@ variable "DD_API_KEY" {
 
 variable "SENTRY_DSN" {
   description = "The Sentry DSN for error tracking"
+  default     = null
 }
 
 variable "FIREBASE_PROJECT_ID" {
@@ -146,8 +147,10 @@ variable "FIREBASE_CLIENT_X509_CERT_URL" {
 
 variable "GA4_MEASUREMENT_ID" {
   description = "The GA4 Measurement ID (G-XXXXXXXXXX) for the backend Measurement Protocol client"
+  default     = null
 }
 
 variable "GA4_API_SECRET" {
   description = "The GA4 Measurement Protocol API secret for the backend analytics client"
+  default     = null
 }

--- a/terraform/modules/environment/secretsmanager/main.tf
+++ b/terraform/modules/environment/secretsmanager/main.tf
@@ -43,16 +43,16 @@ resource "aws_secretsmanager_secret_version" "helium_secret_version" {
       PLATFORM_DB_PASSWORD                   = var.db_password
       PLATFORM_SECRET_KEY                    = random_password.platform_secret.result
       PROJECT_DATADOG_API_KEY                = var.datadog_api_key
-      PLATFORM_SENTRY_DSN                    = var.sentry_dsn
       PLATFORM_FIREBASE_PROJECT_ID           = var.firebase_project_id
       PLATFORM_FIREBASE_PRIVATE_KEY_ID       = var.firebase_private_key_id
       PLATFORM_FIREBASE_PRIVATE_KEY          = var.firebase_private_key
       PLATFORM_FIREBASE_CLIENT_EMAIL         = var.firebase_client_email
       PLATFORM_FIREBASE_CLIENT_ID            = var.firebase_client_id
       PLATFORM_FIREBASE_CLIENT_X509_CERT_URL = var.firebase_client_x509_cert_url
-      PLATFORM_GA4_MEASUREMENT_ID            = var.ga4_measurement_id
-      PLATFORM_GA4_API_SECRET                = var.ga4_api_secret
     },
-    var.ci_app_host != null ? { PROJECT_CI_APP_HOST = "https://${var.ci_app_host}" } : {}
+    var.ci_app_host != null ? { PROJECT_CI_APP_HOST = "https://${var.ci_app_host}" } : {},
+    var.sentry_dsn != null ? { PLATFORM_SENTRY_DSN = var.sentry_dsn } : {},
+    var.ga4_measurement_id != null ? { PLATFORM_GA4_MEASUREMENT_ID = var.ga4_measurement_id } : {},
+    var.ga4_api_secret != null ? { PLATFORM_GA4_API_SECRET = var.ga4_api_secret } : {},
   ))
 }

--- a/terraform/modules/environment/secretsmanager/variables.tf
+++ b/terraform/modules/environment/secretsmanager/variables.tf
@@ -69,7 +69,8 @@ variable "datadog_api_key" {
 }
 
 variable "sentry_dsn" {
-  type = string
+  type    = string
+  default = null
 }
 
 variable "firebase_project_id" {
@@ -97,11 +98,13 @@ variable "firebase_client_x509_cert_url" {
 }
 
 variable "ga4_measurement_id" {
-  type = string
+  type    = string
+  default = null
 }
 
 variable "ga4_api_secret" {
-  type = string
+  type    = string
+  default = null
 }
 
 variable "ci_app_host" {


### PR DESCRIPTION
Conditionally merge PLATFORM_SENTRY_DSN and PLATFORM_GA4_* keys into the helium secret bundle, mirroring the existing PROJECT_CI_APP_HOST pattern, so non-prod workspaces can plan/apply without those values configured.
